### PR TITLE
Add seamless support of pytest-xdist

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,4 +46,4 @@ jobs:
     - name: Test
       shell: bash
       run: |
-        tox -e py --installpkg `find dist/*.tar.gz`
+        tox -e py,xdist --installpkg `find dist/*.tar.gz`

--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ pip install pytest-smoke
 
 ## Usage
 
-The plugin provides the following options, allowing you to limit the amount of tests to run (`N`) and optionally specify 
- the scope at which `N` is applied:
+The plugin provides the following options to limit the amount of tests to run (`N`, default=`1`) and optionally specify 
+the scope at which `N` is applied.    
+If provided, the value of `N` can be either a number (e.g., `5`) or a percentage (e.g., `10%`). 
 ```
 $ pytest -h
 
@@ -44,10 +45,9 @@ Smoke testing:
                         NOTE: You can also implement your own custom scopes using a hook
 ```
 
-> - The value of `N` can be a number (e.g. `5`) or a percentage (e.g. `10%`)
-> - If `N` is not explicitly specified, the default value of `1` will be used
-> - The `--smoke-scope` option supports any custom values, as long as they are handled in the hook
-> - You can overwrite the plugin's default value for `N` and `SCOPE` using INI options. See the "INI Options" section below
+> - The `--smoke-scope` option also supports any custom values, as long as they are handled in the hook
+> - You can override the plugin's default value for `N` and `SCOPE` using INI options. See the "INI Options" section below
+> - When using the `pytest-xdist` plugin for parallel testing, you can configure the `pytest-smoke` plugin to enable a custom distribution algorithm that distributes tests based on the smoke scope
 
 
 ## Examples
@@ -234,7 +234,7 @@ tests/test_something.py::test_something3[17] PASSED              [100%]
 The plugin provides the following hooks to customize or extend the plugin's capabilities: 
 
 ### `pytest_smoke_generate_group_id(item, scope)`
-This hook allows you to implement your own custom scopes for the `--scope-smoke` option, or overwrite the logic of the 
+This hook allows you to implement your own custom scopes for the `--smoke-scope` option, or override the logic of the 
 predefined scopes. Items with the same group ID are grouped together and are considered to be in the same scope, 
 at which `N` is applied. Any custom values passed to the  `--smoke-scope` option must be handled in this hook.
 
@@ -250,7 +250,7 @@ selected.
 
 ## INI Options
 
-You can overwrite the plugin's default values by setting the following options in a configuration 
+You can override the plugin's default values by setting the following options in a configuration 
 file (pytest.ini, pyproject.toml, etc.).  
 
 ### `smoke_default_n`
@@ -260,3 +260,9 @@ Plugin default: `1`
 ### `smoke_default_scope`
 The default smoke scope to be applied when not explicitly specified with the `--smoke-scope` option.  
 Plugin default: `function`
+
+### `smoke_xdist_dist_by_scope`
+When using the `pytest-xdist` plugin (>=2.3.0) for parallel testing, a custom distribution algorithm that 
+distributes tests based on the smoke scope can be enabled. The custom scheduler will be automatically used when 
+the `-n`/`--numprocesses` option is used.   
+Plugin default: `false`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dev = [
     "pytest-xdist[psutil]>=2.5.0,<4",
     "ruff==0.8.3",
     "tox>=4.0.0,<5",
-    "tox-uv>=1.0.0,<2"
+    "tox-uv>=1.0.0,<2",
 ]
 
 [project.urls]

--- a/src/pytest_smoke/__init__.py
+++ b/src/pytest_smoke/__init__.py
@@ -3,5 +3,25 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("pytest-smoke")
 except PackageNotFoundError:
-    # package is not installed
     pass
+
+
+class PytestSmoke:
+    def __init__(self):
+        try:
+            from xdist import __version__ as __xdist_version__
+
+            self._is_xdist_installed = __xdist_version__ >= "2.3.0"
+        except ImportError:
+            self._is_xdist_installed = False
+
+    @property
+    def is_xdist_installed(self) -> bool:
+        return self._is_xdist_installed
+
+    @is_xdist_installed.setter
+    def is_xdist_installed(self, v: bool):
+        self._is_xdist_installed = v
+
+
+smoke = PytestSmoke()

--- a/src/pytest_smoke/extensions/xdist.py
+++ b/src/pytest_smoke/extensions/xdist.py
@@ -1,0 +1,39 @@
+from pytest import Config, Item, Session, hookimpl
+
+from pytest_smoke import smoke
+from pytest_smoke.types import SmokeIniOption
+from pytest_smoke.utils import generate_group_id, get_scope, parse_ini_option
+
+if smoke.is_xdist_installed:
+    from xdist import is_xdist_controller
+    from xdist.scheduler import LoadScopeScheduling
+
+    class PytestSmokeXdist:
+        """A plugin that extends pytest-smoke to seamlesslly support pytest-xdist"""
+
+        name = "smoke-xdist"
+
+        def __init__(self):
+            self._nodes = None
+
+        @hookimpl(tryfirst=True)
+        def pytest_collection(self, session: Session):
+            if is_xdist_controller(session):
+                self._nodes = {item.nodeid: item for item in session.perform_collect()}
+                return True
+
+        def pytest_xdist_make_scheduler(self, config: Config, log):
+            if parse_ini_option(config, SmokeIniOption.SMOKE_XDIST_DIST_BY_SCOPE):
+                return SmokeScopeScheduling(config, log, nodes=self._nodes)
+
+    class SmokeScopeScheduling(LoadScopeScheduling):
+        """A custom pytest-xdist scheduler that distributes workloads by smoke scope groups"""
+
+        def __init__(self, config: Config, log, *, nodes: dict[str, Item]):
+            super().__init__(config, log)
+            self._scope = get_scope(self.config)
+            self._nodes = nodes
+
+        def _split_scope(self, nodeid: str) -> str:
+            item = self._nodes[nodeid]
+            return generate_group_id(item, self._scope) or super()._split_scope(nodeid)

--- a/src/pytest_smoke/hooks.py
+++ b/src/pytest_smoke/hooks.py
@@ -5,7 +5,7 @@ from pytest import Item, hookspec
 def pytest_smoke_generate_group_id(item: Item, scope: str):
     """Return a smoke scope group ID for the predefined or custom scopes
 
-    Use this hook to either overwrite the logic of the predefined scopes or to implement logic for your own scopes
+    Use this hook to either override the logic of the predefined scopes or to implement logic for your own scopes
     NOTE: Any custom scopes given to the --smoke-scope option must be handled in this hook
     """
 

--- a/src/pytest_smoke/types.py
+++ b/src/pytest_smoke/types.py
@@ -1,0 +1,34 @@
+import sys
+from enum import Enum, auto
+
+if sys.version_info < (3, 11):
+
+    class StrEnum(str, Enum):
+        def _generate_next_value_(name, start, count, last_values) -> str:
+            return name.lower()
+
+        def __str__(self) -> str:
+            return str(self.value)
+else:
+    from enum import StrEnum
+
+
+class SmokeEnvVar(StrEnum):
+    SMOKE_TEST_SESSION_UUID = auto()
+
+
+class SmokeScope(StrEnum):
+    FUNCTION = auto()
+    CLASS = auto()
+    AUTO = auto()
+    FILE = auto()
+    ALL = auto()
+
+
+class SmokeIniOption(StrEnum):
+    SMOKE_DEFAULT_N = auto()
+    SMOKE_DEFAULT_SCOPE = auto()
+    SMOKE_XDIST_DIST_BY_SCOPE = auto()
+
+
+class SmokeDefaultN(int): ...

--- a/src/pytest_smoke/utils.py
+++ b/src/pytest_smoke/utils.py
@@ -1,18 +1,11 @@
-import sys
 from decimal import ROUND_HALF_UP, Decimal
-from enum import Enum
 from functools import lru_cache
+from typing import Optional, Union
 
-if sys.version_info.major == 3 and sys.version_info.minor < 11:
+import pytest
+from pytest import Config, Item
 
-    class StrEnum(str, Enum):
-        def _generate_next_value_(name, start, count, last_values) -> str:
-            return name.lower()
-
-        def __str__(self) -> str:
-            return str(self.value)
-else:
-    from enum import StrEnum  # noqa: F401
+from pytest_smoke.types import SmokeIniOption, SmokeScope
 
 
 @lru_cache
@@ -28,6 +21,90 @@ def scale_down(value: float, percentage: float, precision: int = 0, min_value: i
         raise ValueError("The percentage must be 100 or smaller")
     val = _round_half_up(value * percentage / 100, precision)
     return max(val, min_value)
+
+
+@lru_cache
+def generate_group_id(item: Item, scope: str) -> Optional[str]:
+    assert scope
+    if item.config.hook.pytest_smoke_exclude(item=item, scope=scope):
+        return
+
+    if (group_id := item.config.hook.pytest_smoke_generate_group_id(item=item, scope=scope)) is not None:
+        return group_id
+
+    if scope not in [str(x) for x in SmokeScope]:
+        raise pytest.UsageError(
+            f"The logic for the custom scope '{scope}' must be implemented using the "
+            f"pytest_smoke_generate_group_id hook"
+        )
+
+    if scope == SmokeScope.ALL:
+        return "*"
+
+    cls = getattr(item, "cls", None)
+    if not cls and scope == SmokeScope.CLASS:
+        return
+
+    group_id = str(item.path or item.location[0])
+    if scope == SmokeScope.FILE:
+        return group_id
+
+    if cls:
+        group_id += f"::{cls.__name__}"
+        if scope in [SmokeScope.CLASS, SmokeScope.AUTO]:
+            return group_id
+
+    # The default scope
+    func_name = item.function.__name__  # type: ignore
+    group_id += f"::{func_name}"
+    return group_id
+
+
+def parse_n(value: str) -> Union[int, str]:
+    v = value.strip()
+    try:
+        if is_scale := v.endswith("%"):
+            num = float(v[:-1])
+        else:
+            num = int(v)
+
+        if num < 1 or is_scale and num > 100:
+            raise ValueError
+
+        if is_scale:
+            return f"{num}%"
+        else:
+            return num
+    except ValueError:
+        raise pytest.UsageError(
+            f"The smoke N value must be a positive number or a valid percentage. '{value}' was given."
+        )
+
+
+def parse_scope(value: str) -> str:
+    if (v := value.strip()) == "":
+        raise pytest.UsageError(f"Invalid scope: '{value}'")
+    return v
+
+
+def parse_ini_option(config: Config, option: SmokeIniOption) -> Union[str, int, bool]:
+    try:
+        v = config.getini(option)
+        if option == SmokeIniOption.SMOKE_DEFAULT_N:
+            return parse_n(v)
+        elif option == SmokeIniOption.SMOKE_DEFAULT_SCOPE:
+            return parse_scope(v)
+        else:
+            return v
+    except ValueError as e:
+        raise pytest.UsageError(f"{option}: {e}")
+
+
+@lru_cache
+def get_scope(config: Config) -> str:
+    scope = config.option.smoke_scope or parse_ini_option(config, SmokeIniOption.SMOKE_DEFAULT_SCOPE)
+    assert scope
+    return scope
 
 
 def _round_half_up(x: float, precision: int) -> float:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,14 @@
+import os
+
 import pytest
 from pytest import Pytester
 
-from pytest_smoke.utils import StrEnum
+from pytest_smoke import smoke
+
+if os.environ.get("IGNORE_XDIST") == "true":
+    smoke.is_xdist_installed = False
+
+from pytest_smoke.types import StrEnum
 from tests.helper import TestClassSpec, TestFileSpec, TestFuncSpec, generate_test_code
 
 pytest_plugins = "pytester"

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,11 @@
 [tox]
 env_list =
-    linting
     py{39,310}-pytest{7.0,7.1,7.2,7.3,7.4,8.0,8.1,8.2,8.3}
     py311-pytest{7.2,7.3,7.4,8.0,8.1,8.2,8.3}
     py312-pytest{7.3,7.4,8.0,8.1,8.2,8.3}
     py313-pytest{8.2,8.3}
+    xdist{2,3}
+    linting
 
 [testenv]
 package = wheel
@@ -20,7 +21,14 @@ deps =
     pytest7.2: pytest~=7.2.0
     pytest7.1: pytest~=7.1.0
     pytest7.0: pytest~=7.0.0
-commands = pytest tests {posargs:-n auto}
+    xdist2: pytest-xdist~=2.0
+    xdist3: pytest-xdist~=3.0
+set_env =
+    IGNORE_XDIST=true
+    xdist{,2,3}: IGNORE_XDIST=false
+    xdist{,2,3}: _TOX_PYTEST_FILTER_ARGS=-k xdist
+commands =
+    pytest tests {env:_TOX_PYTEST_FILTER_ARGS:} {posargs:-n auto}
 
 [testenv:linting]
 skip_install = True


### PR DESCRIPTION
- Set randm seed when smoke-random option is given
- Add INI option to distribute workloads by the smoke scope using the custom distribution algorithm