### PR TITLE
Change smoke-xdist plugin to apply the custom scheduler only when --dist option is not explicitly given

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Smoke testing:
 
 > - The `--smoke-scope` option also supports any custom values, as long as they are handled in the hook
 > - You can override the plugin's default value for `N` and `SCOPE` using INI options. See the "INI Options" section below
-> - When using the `pytest-xdist` plugin for parallel testing, you can configure the `pytest-smoke` plugin to enable a custom distribution algorithm that distributes tests based on the smoke scope
+> - When using the `pytest-xdist` plugin for parallel testing, you can configure the `pytest-smoke` plugin to replace the default scheduler with a custom distribution algorithm that distributes tests based on the smoke scope
 
 
 ## Examples
@@ -261,8 +261,8 @@ Plugin default: `1`
 The default smoke scope to be applied when not explicitly specified with the `--smoke-scope` option.  
 Plugin default: `function`
 
-### `smoke_xdist_dist_by_scope`
-When using the `pytest-xdist` plugin (>=2.3.0) for parallel testing, a custom distribution algorithm that 
-distributes tests based on the smoke scope can be enabled. The custom scheduler will be automatically used when 
-the `-n`/`--numprocesses` option is used.   
+### `smoke_default_xdist_dist_by_scope`
+When using the `pytest-xdist` plugin (>=2.3.0) for parallel testing, this option replaces the default scheduler with a 
+custom distribution algorithm that distributes tests based on the smoke scope. The custom scheduler will be 
+automatically used when the `-n`/`--numprocesses` option is used without the `--dist` option.   
 Plugin default: `false`

--- a/README.md
+++ b/README.md
@@ -264,5 +264,5 @@ Plugin default: `function`
 ### `smoke_default_xdist_dist_by_scope`
 When using the `pytest-xdist` plugin (>=2.3.0) for parallel testing, this option replaces the default scheduler with a 
 custom distribution algorithm that distributes tests based on the smoke scope. The custom scheduler will be 
-automatically used when the `-n`/`--numprocesses` option is used without the `--dist` option.   
+automatically used when the `-n`/`--numprocesses` option is used without a dist option (`--dist` or `-d`).  
 Plugin default: `false`

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Smoke testing:
 
 > - The `--smoke-scope` option also supports any custom values, as long as they are handled in the hook
 > - You can override the plugin's default value for `N` and `SCOPE` using INI options. See the "INI Options" section below
-> - When using the `pytest-xdist` plugin for parallel testing, you can configure the `pytest-smoke` plugin to replace the default scheduler with a custom distribution algorithm that distributes tests based on the smoke scope
+> - When using the [pytest-xdist](https://pypi.org/project/pytest-xdist/) plugin for parallel testing, you can configure the `pytest-smoke` plugin to replace the default scheduler with a custom distribution algorithm that distributes tests based on the smoke scope
 
 
 ## Examples
@@ -262,7 +262,8 @@ The default smoke scope to be applied when not explicitly specified with the `--
 Plugin default: `function`
 
 ### `smoke_default_xdist_dist_by_scope`
-When using the `pytest-xdist` plugin (>=2.3.0) for parallel testing, this option replaces the default scheduler with a 
-custom distribution algorithm that distributes tests based on the smoke scope. The custom scheduler will be 
-automatically used when the `-n`/`--numprocesses` option is used without a dist option (`--dist` or `-d`).  
+When using the [pytest-xdist](https://pypi.org/project/pytest-xdist/) plugin (>=2.3.0) for parallel testing, this 
+option replaces the default scheduler with a custom distribution algorithm that distributes tests based on the smoke 
+scope. The custom scheduler will be automatically used when the `-n`/`--numprocesses` option is used without a dist 
+option (`--dist` or `-d`).  
 Plugin default: `false`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,10 +36,14 @@ dynamic = ["version"]
 [project.optional-dependencies]
 dev = [
     "pre-commit>=3.0.0,<5",
-    "pytest-xdist[psutil]>=2.5.0,<4",
     "ruff==0.8.3",
     "tox>=4.0.0,<5",
     "tox-uv>=1.0.0,<2",
+    "pytest-smoke[test]"
+]
+test = [
+    "pytest-mock>=3.0.0,<4",
+    "pytest-xdist[psutil]>=2.3.0,<4"
 ]
 
 [project.urls]

--- a/src/pytest_smoke/extensions/xdist.py
+++ b/src/pytest_smoke/extensions/xdist.py
@@ -9,7 +9,10 @@ if smoke.is_xdist_installed:
     from xdist.scheduler import LoadScopeScheduling
 
     class PytestSmokeXdist:
-        """A plugin that extends pytest-smoke to seamlesslly support pytest-xdist"""
+        """A plugin that extends pytest-smoke to seamlesslly support pytest-xdist
+
+        This plugin will be dynamically registered when the -n/--numprocesses option is given
+        """
 
         name = "smoke-xdist"
 
@@ -23,7 +26,14 @@ if smoke.is_xdist_installed:
                 return True
 
         def pytest_xdist_make_scheduler(self, config: Config, log):
-            if parse_ini_option(config, SmokeIniOption.SMOKE_XDIST_DIST_BY_SCOPE):
+            """Replace the pytest-xdist default scheduler (load) with our custom scheduler (smoke scope) when the
+            following conditions match:
+            - The INI option value is set to true
+            - --dist option is not given
+            """
+            if config.known_args_namespace.dist == "no" and parse_ini_option(
+                config, SmokeIniOption.SMOKE_DEFAULT_XDIST_DIST_BY_SCOPE
+            ):
                 return SmokeScopeScheduling(config, log, nodes=self._nodes)
 
     class SmokeScopeScheduling(LoadScopeScheduling):

--- a/src/pytest_smoke/extensions/xdist.py
+++ b/src/pytest_smoke/extensions/xdist.py
@@ -29,10 +29,12 @@ if smoke.is_xdist_installed:
             """Replace the pytest-xdist default scheduler (load) with our custom scheduler (smoke scope) when the
             following conditions match:
             - The INI option value is set to true
-            - --dist option is not given
+            - No dist option (--dist or -d) is explicitly given
             """
-            if config.known_args_namespace.dist == "no" and parse_ini_option(
-                config, SmokeIniOption.SMOKE_DEFAULT_XDIST_DIST_BY_SCOPE
+            if (
+                config.known_args_namespace.dist == "no"
+                and not config.known_args_namespace.distload
+                and parse_ini_option(config, SmokeIniOption.SMOKE_DEFAULT_XDIST_DIST_BY_SCOPE)
             ):
                 return SmokeScopeScheduling(config, log, nodes=self._nodes)
 

--- a/src/pytest_smoke/plugin.py
+++ b/src/pytest_smoke/plugin.py
@@ -119,7 +119,7 @@ def pytest_configure(config: Config):
     if smoke.is_xdist_installed:
         if config.pluginmanager.has_plugin("xdist"):
             # Register the smoke-xdist plugin if -n/--numprocesses option is given.
-            if smoke.is_xdist_installed and config.getoption("numprocesses", default=None):
+            if config.getoption("numprocesses", default=None):
                 config.pluginmanager.register(PytestSmokeXdist(), name=PytestSmokeXdist.name)
         else:
             smoke.is_xdist_installed = False

--- a/src/pytest_smoke/plugin.py
+++ b/src/pytest_smoke/plugin.py
@@ -96,11 +96,11 @@ def pytest_addoption(parser: Parser):
         help="[pytest-smoke] Override the plugin default value for smoke scope",
     )
     parser.addini(
-        SmokeIniOption.SMOKE_XDIST_DIST_BY_SCOPE,
+        SmokeIniOption.SMOKE_DEFAULT_XDIST_DIST_BY_SCOPE,
         type="bool",
         default=False,
-        help="[pytest-smoke] When using the pytest-xdist plugin for parallel testing, a custom distribution algorithm "
-        "that distributes tests based on the smoke scope can be enabled",
+        help="[pytest-smoke] When using the pytest-xdist plugin for parallel testing, replace the default scheduler "
+        "with a custom distribution algorithm that distributes tests based on the smoke scope",
     )
 
 

--- a/src/pytest_smoke/types.py
+++ b/src/pytest_smoke/types.py
@@ -28,7 +28,7 @@ class SmokeScope(StrEnum):
 class SmokeIniOption(StrEnum):
     SMOKE_DEFAULT_N = auto()
     SMOKE_DEFAULT_SCOPE = auto()
-    SMOKE_XDIST_DIST_BY_SCOPE = auto()
+    SMOKE_DEFAULT_XDIST_DIST_BY_SCOPE = auto()
 
 
 class SmokeDefaultN(int): ...

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import os
 
 import pytest
 from pytest import Pytester
+from pytest_mock import MockerFixture
 
 from pytest_smoke import smoke
 
@@ -19,6 +20,14 @@ def pytest_make_parametrize_id(val, argname):
     if isinstance(val, StrEnum):
         val = str(val)
     return f"{argname}={repr(val)}"
+
+
+@pytest.fixture(autouse=True)
+def mock_is_xdist_installed(mocker: MockerFixture):
+    """Mock the smoke.is_xdist_installed flag value to limit the effect of a change the plugin will make during some
+    tests to be within a test
+    """
+    mocker.patch.object(smoke, "_is_xdist_installed", return_value=smoke.is_xdist_installed)
 
 
 @pytest.fixture(scope="session")

--- a/tox.ini
+++ b/tox.ini
@@ -10,8 +10,8 @@ env_list =
 [testenv]
 package = wheel
 wheel_build_env = .pkg
+extras = test
 deps =
-    pytest-xdist[psutil]
     pytest8.3: pytest~=8.3.0
     pytest8.2: pytest~=8.2.0
     pytest8.1: pytest~=8.1.0


### PR DESCRIPTION
Also change the INI option name to smoke_default_xdist_dist_by_scope