### PR TITLE
Changes around the default smoke scope and the behavior of auto scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ versions](https://img.shields.io/pypi/pyversions/pytest-smoke.svg)](https://pypi
 [![Code style ruff](https://img.shields.io/badge/code%20style-ruff-000000.svg)](https://docs.astral.sh/ruff/)
 
 `pytest-smoke` is a `pytest` plugin designed to quickly perform smoke testing on large test suites. It allows you to 
-scale down test execution by limiting the number of tests run from each test function or specified scope to a smaller 
-subset, defined by a value of `N`.
+scale down test execution by limiting the number of tests run from logical groupings (*smoke scopes*) to a smaller 
+subset defined by `N`. 
 
 
 ## Installation
@@ -36,17 +36,19 @@ $ pytest -h
 <snip>
 
 Smoke testing:
-  --smoke=[N]           Run only N tests from each test function or specified scope.
+  --smoke=[N]           Run only N tests from each smoke scope.
                         N can be a number (e.g. 5) or a percentage (e.g. 10%).
                         If not provided, the default value is 1.
   --smoke-scope=SCOPE   Specify the scope at which the value of N from the above options is applied.
                         The plugin provides the following predefined scopes, as well as custom user-defined scopes via a hook:
-                        - function: Applies to each test function (default)
-                        - class: Applies to each test class
-                        - auto: Applies function scope for test functions, class scope for test methods
-                        - file: Applies to each test file
-                        - directory: Applies to each test directory
-                        - all: Applies to the entire test suite
+                        - function: Applies N to each test function
+                        - class: Applies N to each test class
+                        - file: Applies N to each test file
+                        - directory: Applies N to each directory a test file is stored
+                        - all: Applies N to the entire test suite
+                        - auto (default): Dynamically determines an ideal scope per parent node (module or class) based on the presence
+                        of parametrized tests. Uses function scope if any parameterized tests exist under the parent node. Otherwise,
+                        falls back to file scope for test functions or class scope for test methods.
   --smoke-select-mode=MODE
                         Specify the mode for selecting tests from each scope.
                         The plugin provides the following predefined values, as well as custom user-defined values via a hook:
@@ -194,7 +196,7 @@ Plugin default: `1`
 
 ### `smoke_default_scope`
 The default smoke scope to be applied when not explicitly specified with the `--smoke-scope` option.  
-Plugin default: `function`
+Plugin default: `auto`
 
 ### `smoke_default_select_mode`
 The default smoke select mode to be applied when not explicitly specified with the `--smoke-select-mode` 

--- a/src/pytest_smoke/plugin.py
+++ b/src/pytest_smoke/plugin.py
@@ -64,7 +64,7 @@ def pytest_addoption(parser: Parser) -> None:
         type=parse_n,
         nargs="?",
         default=False,
-        help="Run only N tests from each test function or specified scope.\n"
+        help="Run only N tests from each smoke scope.\n"
         "N can be a number (e.g. 5) or a percentage (e.g. 10%%).\n"
         "If not provided, the default value is 1.",
     )
@@ -76,13 +76,15 @@ def pytest_addoption(parser: Parser) -> None:
         help=(
             "Specify the scope at which the value of N from the above options is applied.\n"
             "The plugin provides the following predefined scopes, as well as custom user-defined scopes via a hook:\n"
-            f"- {SmokeScope.FUNCTION}: Applies to each test function (default)\n"
-            f"- {SmokeScope.CLASS}: Applies to each test class\n"
-            f"- {SmokeScope.AUTO}: Applies {SmokeScope.FUNCTION} scope for test functions, "
-            f"{SmokeScope.CLASS} scope for test methods\n"
-            f"- {SmokeScope.FILE}: Applies to each test file\n"
-            f"- {SmokeScope.DIRECTORY}: Applies to each test directory\n"
-            f"- {SmokeScope.ALL}: Applies to the entire test suite"
+            f"- {SmokeScope.FUNCTION}: Applies N to each test function\n"
+            f"- {SmokeScope.CLASS}: Applies N to each test class\n"
+            f"- {SmokeScope.FILE}: Applies N to each test file\n"
+            f"- {SmokeScope.DIRECTORY}: Applies N to each directory a test file is stored\n"
+            f"- {SmokeScope.ALL}: Applies N to the entire test suite\n"
+            f"- {SmokeScope.AUTO} (default): Dynamically determines an ideal scope per parent node (module or class) "
+            "based on the presence of parametrized tests. Uses function scope if any parameterized tests exist under "
+            f"the parent node. Otherwise, falls back to {SmokeScope.FILE} scope for test functions or "
+            f"{SmokeScope.CLASS} scope for test methods."
         ),
     )
     group.addoption(
@@ -108,7 +110,7 @@ def pytest_addoption(parser: Parser) -> None:
     parser.addini(
         SmokeIniOption.SMOKE_DEFAULT_SCOPE,
         type="string",
-        default=SmokeScope.FUNCTION,
+        default=SmokeScope.AUTO,
         help="[pytest-smoke] Override the plugin default value for smoke scope",
     )
     parser.addini(

--- a/src/pytest_smoke/plugin.py
+++ b/src/pytest_smoke/plugin.py
@@ -22,6 +22,7 @@ from pytest_smoke.types import (
     SmokeSelectMode,
 )
 from pytest_smoke.utils import (
+    Cache,
     generate_group_id,
     parse_ini_option,
     parse_n,
@@ -176,65 +177,66 @@ def pytest_collection_modifyitems(session: Session, config: Config, items: list[
 
         opt = SmokeOption(config)
         if opt.n:
-            selected_items_regular = []
-            selected_items_critical = []
-            deselected_items = []
-            smoke_groups_reached_threshold = set()
-            counter = SmokeCounter(
-                collected=Counter(filter(None, (generate_group_id(item, opt.scope) for item in items)))
-            )
-            session.stash[STASH_KEY_SMOKE_COUNTER] = counter
-            enable_critical_tests = parse_ini_option(config, SmokeIniOption.SMOKE_MARKED_TESTS_AS_CRITICAL)
+            with Cache.manage():
+                selected_items_regular = []
+                selected_items_critical = []
+                deselected_items = []
+                smoke_groups_reached_threshold = set()
+                counter = SmokeCounter(
+                    collected=Counter(filter(None, (generate_group_id(item, opt.scope) for item in items)))
+                )
+                session.stash[STASH_KEY_SMOKE_COUNTER] = counter
+                enable_critical_tests = parse_ini_option(config, SmokeIniOption.SMOKE_MARKED_TESTS_AS_CRITICAL)
 
-            for item in sort_items(items, session, opt):
-                group_id = generate_group_id(item, opt.scope)
-                if group_id is None:
-                    deselected_items.append(item)
-                    continue
-
-                # Tests that match the below conditions will not be counted towards the calculation of N
-                if enable_critical_tests and (smoke_marker := SmokeMarker.from_item(item)):
-                    if smoke_marker.runif:
-                        selected_items_critical.append(item)
-                        if smoke_marker.mustpass:
-                            counter.mustpass.selected.add(item)
-                        item.stash[STASH_KEY_SMOKE_IS_CIRITICAL] = True
-                        item.stash[STASH_KEY_SMOKE_IS_MUSTPASS] = smoke_marker.mustpass
-                    else:
+                for item in sort_items(items, session, opt):
+                    group_id = generate_group_id(item, opt.scope)
+                    if group_id is None:
                         deselected_items.append(item)
-                    continue
-                elif config.hook.pytest_smoke_include(item=item, scope=opt.scope):
-                    selected_items_regular.append(item)
-                    continue
+                        continue
 
-                if group_id in smoke_groups_reached_threshold:
-                    deselected_items.append(item)
-                    continue
+                    # Tests that match the below conditions will not be counted towards the calculation of N
+                    if enable_critical_tests and (smoke_marker := SmokeMarker.from_item(item)):
+                        if smoke_marker.runif:
+                            selected_items_critical.append(item)
+                            if smoke_marker.mustpass:
+                                counter.mustpass.selected.add(item)
+                            item.stash[STASH_KEY_SMOKE_IS_CIRITICAL] = True
+                            item.stash[STASH_KEY_SMOKE_IS_MUSTPASS] = smoke_marker.mustpass
+                        else:
+                            deselected_items.append(item)
+                        continue
+                    elif config.hook.pytest_smoke_include(item=item, scope=opt.scope):
+                        selected_items_regular.append(item)
+                        continue
 
-                if opt.is_scale:
-                    threshold = scale_down(counter.collected[group_id], float(cast(str, opt.n)[:-1]))
-                else:
-                    threshold = cast(int, opt.n)
-                if counter.selected[group_id] < threshold:
-                    counter.selected.update([group_id])
-                    selected_items_regular.append(item)
-                else:
-                    smoke_groups_reached_threshold.add(group_id)
-                    deselected_items.append(item)
+                    if group_id in smoke_groups_reached_threshold:
+                        deselected_items.append(item)
+                        continue
 
-            assert len(items) == len(selected_items_critical + selected_items_regular + deselected_items)
-            if selected_items_critical or deselected_items:
-                if deselected_items:
-                    config.hook.pytest_deselected(items=deselected_items)
+                    if opt.is_scale:
+                        threshold = scale_down(counter.collected[group_id], float(cast(str, opt.n)[:-1]))
+                    else:
+                        threshold = cast(int, opt.n)
+                    if counter.selected[group_id] < threshold:
+                        counter.selected.update([group_id])
+                        selected_items_regular.append(item)
+                    else:
+                        smoke_groups_reached_threshold.add(group_id)
+                        deselected_items.append(item)
 
-                if opt.select_mode != SmokeSelectMode.FIRST:
-                    # retain the original test order
-                    for smoke_items in (selected_items_critical, selected_items_regular):
-                        if smoke_items:
-                            smoke_items.sort(key=lambda x: items.index(x))
+                assert len(items) == len(selected_items_critical + selected_items_regular + deselected_items)
+                if selected_items_critical or deselected_items:
+                    if deselected_items:
+                        config.hook.pytest_deselected(items=deselected_items)
 
-                items.clear()
-                items.extend(selected_items_critical + selected_items_regular)
+                    if opt.select_mode != SmokeSelectMode.FIRST:
+                        # retain the original test order
+                        for smoke_items in (selected_items_critical, selected_items_regular):
+                            if smoke_items:
+                                smoke_items.sort(key=lambda x: items.index(x))
+
+                    items.clear()
+                    items.extend(selected_items_critical + selected_items_regular)
 
 
 @pytest.hookimpl(wrapper=True)

--- a/src/pytest_smoke/types.py
+++ b/src/pytest_smoke/types.py
@@ -6,10 +6,10 @@ from enum import auto
 from functools import cached_property
 from typing import TYPE_CHECKING, Any
 
+from pytest_smoke.compat import StrEnum
+
 if TYPE_CHECKING:
     from pytest import Config, Item
-
-from pytest_smoke.compat import StrEnum
 
 
 class SmokeEnvVar(StrEnum):
@@ -19,10 +19,10 @@ class SmokeEnvVar(StrEnum):
 class SmokeScope(StrEnum):
     FUNCTION = auto()
     CLASS = auto()
-    AUTO = auto()
     FILE = auto()
     DIRECTORY = auto()
     ALL = auto()
+    AUTO = auto()
 
 
 class SmokeSelectMode(StrEnum):

--- a/src/pytest_smoke/utils.py
+++ b/src/pytest_smoke/utils.py
@@ -9,7 +9,6 @@ from typing import TYPE_CHECKING, cast
 from uuid import UUID
 
 import pytest
-from _pytest.nodes import Node
 from pytest import Class, Function
 
 from pytest_smoke import smoke
@@ -19,6 +18,7 @@ if smoke.is_xdist_installed:
     from xdist import is_xdist_controller, is_xdist_worker
 
 if TYPE_CHECKING:
+    from _pytest.nodes import Node
     from pytest import Config, Item, Session
 
 
@@ -44,13 +44,6 @@ def generate_group_id(item: Item, scope: str) -> str | None:
     :param item: Collected Pytest item
     :param scope: Smoke scope
     """
-
-    def _generate_class_group_id(current_item: Node, class_id: str = "") -> str:
-        parent = current_item.parent
-        if isinstance(parent, Class):
-            return _generate_class_group_id(parent, class_id=f"::{parent.name}{class_id}")
-        return class_id
-
     assert scope
     if item.config.hook.pytest_smoke_exclude(item=item, scope=scope):
         return None
@@ -58,36 +51,20 @@ def generate_group_id(item: Item, scope: str) -> str | None:
     if (group_id := item.config.hook.pytest_smoke_generate_group_id(item=item, scope=scope)) is not None:
         return group_id
 
-    if scope not in [str(x) for x in SmokeScope]:
-        raise pytest.UsageError(
-            f"The logic for the custom scope '{scope}' must be implemented using the "
-            f"pytest_smoke_generate_group_id hook"
-        )
+    return _generate_scope_group_id(item, scope)
 
-    if scope == SmokeScope.ALL:
-        return "*"
 
-    is_class_method = isinstance(item.parent, Class)
-    if not is_class_method and scope == SmokeScope.CLASS:
-        return None
+@lru_cache
+def has_parametrized_test(node: Node) -> bool:
+    """Check if at least one parametrized test exists in the node
 
-    file_path = item.path
-    if scope == SmokeScope.DIRECTORY:
-        return str(file_path.parent)
-
-    group_id = str(file_path)
-    if scope == SmokeScope.FILE:
-        return group_id
-
-    if is_class_method:
-        group_id += _generate_class_group_id(item)
-        if scope in [SmokeScope.CLASS, SmokeScope.AUTO]:
-            return group_id
-
-    # function scope
-    func_name = cast(Function, item).function.__name__
-    group_id += f"::{func_name}"
-    return group_id
+    :param node: Pytest node
+    """
+    node_items = tuple(x for x in node.session.items if x.parent == node)
+    for node_item in node_items:
+        if node_item.get_closest_marker("parametrize"):
+            return True
+    return False
 
 
 def sort_items(items: list[Item], session: Session, smoke_option: SmokeOption) -> list[Item]:
@@ -171,3 +148,51 @@ def parse_ini_option(config: Config, option: SmokeIniOption) -> str | int | floa
 
 def _round_half_up(x: float, precision: int) -> float:
     return float(Decimal(str(x)).quantize(Decimal("10") ** -precision, rounding=ROUND_HALF_UP))
+
+
+@lru_cache
+def _generate_scope_group_id(item: Item, scope: str) -> str | None:
+    def _generate_class_group_id(current_item: Node, class_id: str = "") -> str:
+        parent = current_item.parent
+        if isinstance(parent, Class):
+            return _generate_class_group_id(parent, class_id=f"::{parent.name}{class_id}")
+        return class_id
+
+    if scope not in [str(x) for x in SmokeScope]:
+        raise pytest.UsageError(
+            f"The logic for the custom scope '{scope}' must be implemented using the "
+            f"pytest_smoke_generate_group_id hook"
+        )
+
+    if scope == SmokeScope.ALL:
+        return "*"
+
+    is_class_method = isinstance(item.parent, Class)
+    if not is_class_method and scope == SmokeScope.CLASS:
+        return None
+
+    file_path = item.path
+    if scope == SmokeScope.DIRECTORY:
+        return str(file_path.parent)
+
+    group_id = str(file_path)
+    if scope == SmokeScope.FILE:
+        return group_id
+
+    if is_class_method:
+        group_id += _generate_class_group_id(item)
+        if scope == SmokeScope.CLASS:
+            return group_id
+
+    # function or auto scope
+    assert scope in [SmokeScope.FUNCTION, SmokeScope.AUTO]
+    if scope == SmokeScope.FUNCTION or has_parametrized_test(item.parent):
+        func_name = cast(Function, item).function.__name__
+        return f"{group_id}::{func_name}"
+    else:
+        # The parent node has no parametrized tests. Fall back to file or class scope
+        if is_class_method:
+            dynamic_scope = SmokeScope.CLASS
+        else:
+            dynamic_scope = SmokeScope.FILE
+        return _generate_scope_group_id(item, dynamic_scope)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,28 +35,38 @@ def mock_is_xdist_installed(mocker: MockerFixture) -> None:
 @pytest.fixture(scope="session")
 def test_file_specs() -> list[TestFileSpec]:
     """Specifications for test files to generate"""
-    # file1: A test file with non-parametrized test functions
+    # file1: Non-parametrized test functions
     test_file_spec1 = TestFileSpec([TestFuncSpec(), TestFuncSpec()])
-    # file2: A test file with parametrized test functions
-    test_file_spec2 = TestFileSpec([TestFuncSpec(num_params=10), TestFuncSpec(num_params=20)])
-    # file3: A test file with test classes, with/without class-level parametrization
+    # file2: With parametrized test functions
+    test_file_spec2 = TestFileSpec([TestFuncSpec(), TestFuncSpec(num_params=10), TestFuncSpec(num_params=20)])
+    # file3: Test classes with/without class-level parametrization and with/without nested test classes
     test_file_spec3 = TestFileSpec(
         [
-            TestClassSpec("Test1", [TestFuncSpec(num_params=5), TestFuncSpec()]),
-            TestClassSpec("Test2", [TestFuncSpec(num_params=5), TestFuncSpec(num_params=10)]),
-            TestClassSpec("Test3", [TestFuncSpec(num_params=3), TestFuncSpec()], num_params=2),
+            TestClassSpec("Test1", [TestFuncSpec(), TestFuncSpec()]),
+            TestClassSpec("Test2", [TestFuncSpec(), TestFuncSpec(num_params=5), TestFuncSpec(num_params=10)]),
+            TestClassSpec("Test3", [TestFuncSpec(), TestFuncSpec(num_params=3)], num_params=2),
             TestClassSpec(
                 "Test4",
-                [TestFuncSpec()],
+                [TestFuncSpec(), TestFuncSpec()],
+                nested_test_class_specs=[
+                    TestClassSpec("TestNested1", [TestFuncSpec(), TestFuncSpec()]),
+                    TestClassSpec("TestNested2", [TestFuncSpec(), TestFuncSpec(num_params=3)]),
+                    TestClassSpec("TestNested3", [TestFuncSpec(), TestFuncSpec(num_params=2)], num_params=3),
+                ],
+            ),
+            TestClassSpec(
+                "Test5",
+                [TestFuncSpec(), TestFuncSpec()],
                 num_params=2,
                 nested_test_class_specs=[
-                    TestClassSpec("TestNested1", [TestFuncSpec(), TestFuncSpec(num_params=3)]),
-                    TestClassSpec("TestNested2", [TestFuncSpec(), TestFuncSpec(num_params=2)], num_params=3),
+                    TestClassSpec("TestNested1", [TestFuncSpec(), TestFuncSpec()]),
+                    TestClassSpec("TestNested2", [TestFuncSpec(), TestFuncSpec(num_params=3)]),
+                    TestClassSpec("TestNested3", [TestFuncSpec(), TestFuncSpec(num_params=2)], num_params=3),
                 ],
             ),
         ]
     )
-    # file4: A test file with a mix of everything above, inside a sub directory
+    # file4: A mix of everything above, inside a sub directory
     test_file_spec4 = TestFileSpec(
         [*test_file_spec1.test_specs, *test_file_spec2.test_specs, *test_file_spec3.test_specs],
         test_dir="tests_something1",

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -27,7 +27,12 @@ def test_smoke_command_help(pytester: Pytester) -> None:
         r"\n"
         + r"Smoke testing:\n"
         + (r"  --smoke=\[N\]\s+.+")
-        + (r"  --smoke-scope=SCOPE\s+.+" + r"\n".join(rf"\s+- {s}: .+" for s in SmokeScope))
+        + (
+            r"  --smoke-scope=SCOPE\s+.+"
+            + r"\n".join(
+                rf"\s+- {s + (re.escape(' (default)') if s == SmokeScope.AUTO else '')}: .+" for s in SmokeScope
+            )
+        )
         + (r"  --smoke-select-mode=MODE\s+.+" + r"\n".join(rf"\s+- {s}: .+" for s in SmokeSelectMode))
         + r"\n"
     )


### PR DESCRIPTION
This PR changes the default `--smoke-scope` option value from `function` to `auto`, and changes the logic of auto scope to dynamically determine the effective scope based on the presence of parametrized tests.